### PR TITLE
Make it 'deadly cold' at the top of maps

### DIFF
--- a/cold_skies/init.lua
+++ b/cold_skies/init.lua
@@ -1,5 +1,5 @@
 local cold_players = {}
-
+local COLD_START_HEIGHT = ctf_map.map.h / 2 - 10
 local dstep = 0
 minetest.register_globalstep(function(dtime)
 	dstep = dstep + dtime

--- a/cold_skies/init.lua
+++ b/cold_skies/init.lua
@@ -13,7 +13,7 @@ minetest.register_globalstep(function(dtime)
 	for _, player in pairs(minetest.get_connected_players()) do
 		local pos = player:get_pos()
 
-		if pos.y >= (ctf_map.map.h / 2 - 10) then
+		if pos.y >= COLD_START_HEIGHT then
 			local name = player:get_player_name()
 
 			if not cold_players[name] then
@@ -41,7 +41,7 @@ minetest.register_globalstep(function(dtime)
 			cold_players[name] = nil
 		end
 
-		if player:get_pos().y <= (ctf_map.map.h / 2 - 10) then
+		if player:get_pos().y <= COLD_START_HEIGHT then
 			player:hud_remove(hudkey)
 			cold_players[name] = nil
 		end

--- a/cold_skies/init.lua
+++ b/cold_skies/init.lua
@@ -1,5 +1,5 @@
 local cold_players = {}
-local COLD_START_HEIGHT = ctf_map.map.h / 2 - 10
+
 local dstep = 0
 minetest.register_globalstep(function(dtime)
 	dstep = dstep + dtime
@@ -8,6 +8,7 @@ minetest.register_globalstep(function(dtime)
 		return
 	end
 
+	local COLD_START_HEIGHT = ctf_map.map.h / 2 - 10
 	dstep = 0
 
 	for _, player in pairs(minetest.get_connected_players()) do

--- a/cold_skies/init.lua
+++ b/cold_skies/init.lua
@@ -1,0 +1,49 @@
+local cold_players = {}
+
+local dstep = 0
+minetest.register_globalstep(function(dtime)
+	dstep = dstep + dtime
+
+	if dstep <= 3 or not ctf_map.map then
+		return
+	end
+
+	dstep = 0
+
+	for _, player in pairs(minetest.get_connected_players()) do
+		local pos = player:get_pos()
+
+		if pos.y >= (ctf_map.map.h / 2 - 10) then
+			local name = player:get_player_name()
+
+			if not cold_players[name] then
+				cold_players[name] = player:hud_add({
+					hud_elem_type = "text",
+					position = {x=0.5, y=0.3},
+					name = "_hud",
+					scale = {x=200, y=200},
+					text = "You are cold. Get to a lower elevation before you freeze!",
+					number = 0x2b9ae6,
+					direction = 1,
+					alignment = {x=0, y=0},
+					offset = {x=0, y=0},
+				})
+			end
+
+			player:set_hp(player:get_hp() - 1)
+		end
+	end
+
+	for name, hudkey in pairs(cold_players) do
+		local player = minetest.get_player_by_name(name)
+
+		if not player then
+			cold_players[name] = nil
+		end
+
+		if player:get_pos().y <= (ctf_map.map.h / 2 - 10) then
+			player:hud_remove(hudkey)
+			cold_players[name] = nil
+		end
+	end
+end)

--- a/cold_skies/mod.conf
+++ b/cold_skies/mod.conf
@@ -1,0 +1,1 @@
+name = cold_skies


### PR DESCRIPTION
Made this to help assist with the snow from #2 not spawning at the very top of the map. Be interesting to see how this affects nerd-polers that go straight to the top of the map too

* Damage may need to be increased, please test and give feedback on that
* Cold area at the top of the map may need to be enlarged, please test and give feedback on that

The only time you'd notice this in normal gameplay is in the top part of the treasure room in Thomas-S's map and in the sky islands in the Big Ocean map