### PR TITLE
Add a license file providing the used licenses

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,99 @@
+License of source code
+-----------------------
+
+The MIT license
+Copyright (C) 2019-2023 rubenwardy and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the “Software”), to deal in the
+Software without restriction, including without limitation the rights to use, copy,
+modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more details:
+https://opensource.org/license/mit/
+
+Licenses of media (textures)
+----------------------------
+
+Attribution-ShareAlike 3.0 Unported (CC BY-SA 3.0)
+Copyright (C) 2017 paramat
+
+You are free to:
+
+Share — copy and redistribute the material in any medium or format for any
+purpose, even commercially.
+
+Adapt — remix, transform, and build upon the material for any purpose, even
+commercially.
+
+The licensor cannot revoke these freedoms as long as you follow the license
+terms.
+
+Under the following terms:
+
+Attribution — You must give appropriate credit, provide a link to the license,
+and indicate if changes were made . You may do so in any reasonable manner,
+but not in any way that suggests the licensor endorses you or your use.
+
+ShareAlike — If you remix, transform, or build upon the material, you must
+distribute your contributions under the same license as the original.
+
+No additional restrictions — You may not apply legal terms or technological
+measures that legally restrict others from doing anything the license permits.
+
+Notices:
+
+You do not have to comply with the license for elements of the material in the public
+domain or where your use is permitted by an applicable exception or limitation.
+
+No warranties are given. The license may not give you all of the permissions necessary for
+your intended use. For example, other rights such as publicity, privacy, or moral rights
+may limit how you use the material.
+
+For more details:
+https://creativecommons.org/licenses/by-sa/3.0/
+
+-----------------------
+
+CC0 1.0 Universal (CC0 1.0) Public Domain Dedication
+LoneWolfHT
+
+No Copyright
+
+The person who associated a work with this deed has dedicated the work to
+the public domain by waiving all of his or her rights to the work worldwide
+under copyright law, including all related and neighboring rights, to the extent
+allowed by law.
+
+You can copy, modify, distribute and perform the work, even for commercial
+purposes, all without asking permission. See Other Information below.
+
+Other Information
+
+In no way are the patent or trademark rights of any person affected by CC0,
+nor are the rights that other persons may have in the work or in how the work
+is used, such as publicity or privacy rights.
+
+Unless expressly stated otherwise, the person who associated a work with this
+deed makes no warranties about the work, and disclaims liability for all uses
+of the work, to the fullest extent permitted by applicable law.
+
+When using or citing the work, you should not imply endorsement by the
+author or the affirmer.
+
+For more details:
+https://creativecommons.org/publicdomain/zero/1.0/

--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@ All content must be freely licensed.
 ## Credits
 
 ### Code
+
 * `snow` MIT by LoneWolfHT, rubenwardy, Thomas-S, and GreenXenith
 * `winterize` and `santa_hat_event` MIT by LoneWolfHT
 
 ### Media
 
-* `Snowflakes` CC BY-SA 3.0 by paramat
+* `Snowflakes` CC BY-SA 3.0 by paramat from <https://github.com/paramat/snowdrift/tree/master/textures>
 * `Winterize` CC0 Universal by LoneWolfHT


### PR DESCRIPTION
Things added/changed:

- Add a license file providing the used licenses.
  - Looks like the media license for `santa_hat_event` is not specified. You may want to specify that on the readme as well as its authors, and in case it's a different license than the mentioned ones, you should add it to the license file, too. This is common to do in mods (see MTG's [`default` mod](https://github.com/minetest/minetest_game/blob/master/mods/default/license.txt)).
